### PR TITLE
Quantisation for IPU

### DIFF
--- a/requirements-dev-ipu.txt
+++ b/requirements-dev-ipu.txt
@@ -4,7 +4,7 @@ flake8==6.0.0
 isort==5.12.0
 mypy==1.0.1
 myst-parser==1.0.0
-poptorch-experimental-addons @ git+https://github.com/graphcore-research/poptorch-experimental-addons@14886d2285c3e45b0eadf4d719dae87d5f28b109
+poptorch-experimental-addons @ git+https://github.com/graphcore-research/poptorch-experimental-addons@beb12678d1e7ea2c033bd061d32167be262dfa58
 pytest==7.2.1
 pytest-cov==4.0.0
 sphinx==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,20 @@ from pathlib import Path
 
 import setuptools
 
+requirements = Path("requirements.txt").read_text().rstrip("\n").split("\n")
+try:
+    import poptorch
+
+    # This should match requirements-dev-ipu.txt
+    requirements.append(
+        "git+https://github.com/graphcore-research/poptorch-experimental-addons@beb12678d1e7ea2c033bd061d32167be262dfa58"
+    )
+except ImportError:
+    pass
+
 setuptools.setup(
     name="unit-scaling",
     description="A library for unit scaling in PyTorch.",
     packages=["unit_scaling"],
-    install_requires=Path("requirements.txt").read_text().rstrip("\n").split("\n"),
+    install_requires=requirements,
 )

--- a/unit_scaling/_modules.py
+++ b/unit_scaling/_modules.py
@@ -22,17 +22,23 @@ from .docs import (
 @inherit_docstring(
     short_description="Applies a **unit-scaled** Gaussian Error Linear Units function:",
     add_args=[binary_constraint_docstring],
+    unsupported_args=["approximate"],
 )
 class GELU(nn.GELU):
     def __init__(
         self,
+        approximate: str = "none",
         constraint: Optional[str] = "gmean",
     ) -> None:
-        super().__init__()
+        super().__init__(approximate=approximate)
         self.constraint = constraint
 
     def forward(self, input: Tensor) -> Tensor:
-        return U.gelu(input, self.constraint)  # type: ignore
+        return U.gelu(  # type: ignore
+            input,
+            approximate=self.approximate,
+            constraint=self.constraint,
+        )
 
 
 @inherit_docstring(

--- a/unit_scaling/functional.py
+++ b/unit_scaling/functional.py
@@ -68,16 +68,18 @@ def _get_broadcast_sizes(*args: Tensor) -> Tuple[int, ...]:
     F.gelu,
     short_description="Applies a **unit-scaled** GELU function.",
     add_args=[binary_constraint_docstring],
+    unsupported_args=["approximate"],
 )
 def gelu(
     input: Tensor,
+    approximate: str = "none",
     constraint: Optional[str] = "gmean",
 ) -> Tensor:
     # Scale factors determined empirically, assuming unit scaled input & grad
     output_scale = 0.588**-1
     grad_input_scale = 0.675**-1
     scaled_gelu = scale_elementwise(F.gelu, output_scale, grad_input_scale, constraint)
-    return scaled_gelu(input)
+    return scaled_gelu(input, approximate=approximate)
 
 
 @docstring_from(

--- a/unit_scaling/scale.py
+++ b/unit_scaling/scale.py
@@ -16,7 +16,7 @@ try:  # pragma: no cover
     import poptorch_experimental_addons as pea
 
     _poptorch_available = True
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
+except ImportError:  # pragma: no cover
     _poptorch_available = False
 
 

--- a/unit_scaling/tests/test_formats.py
+++ b/unit_scaling/tests/test_formats.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
+import collections
+
 import torch
 
 from ..formats import FPFormat
@@ -8,6 +10,7 @@ from ..formats import FPFormat
 def test_fp_format() -> None:
     fmt = FPFormat(2, 1)
     assert fmt.bits == 4
+    assert str(fmt) == "E2M1-SR"
     assert fmt.max_absolute_value == 3
     assert fmt.min_absolute_normal == 0.5
     assert fmt.min_absolute_subnormal == 0.25
@@ -17,6 +20,22 @@ def test_fp_format() -> None:
     assert set(
         FPFormat(3, 0).quantise_fwd(torch.linspace(-10, 10, steps=1000)).abs().tolist()
     ) == {0, 0.125, 0.25, 0.5, 1, 2, 4, 8}
+
+
+def test_fp_format_rounding() -> None:
+    n = 10000
+    x = -1.35
+
+    y_nearest = FPFormat(2, 1, rounding="nearest").quantise(torch.full((n,), x))
+    assert collections.Counter(y_nearest.tolist()) == {-1.5: n}
+
+    y_stochastic = FPFormat(2, 1, rounding="stochastic").quantise(torch.full((n,), x))
+    count = collections.Counter(y_stochastic.tolist())
+    assert count.keys() == {-1.5, -1.0}
+    expected_ratio = (1.35 - 1.0) / 0.5
+    nearest_ratio = count[-1.5] / sum(count.values())
+    std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
+    assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
 
 
 def test_fp_format_bwd() -> None:

--- a/unit_scaling/tests/test_utils.py
+++ b/unit_scaling/tests/test_utils.py
@@ -30,7 +30,7 @@ def forward(self, input : Tensor) -> Tensor:
     linear_1_weight = self.linear_1.weight;  (-> 1.0, <- 0.716)
     linear_1_bias = self.linear_1.bias;  (-> 0.0, <- 0.714)
     linear = U.linear(input_1, linear_1_weight, linear_1_bias, 'gmean');  (-> 0.707, <- 0.717)
-    gelu = U.gelu(linear, 'gmean');  (-> 0.641, <- 0.708)
+    gelu = U.gelu(linear, approximate = 'none', constraint = 'gmean');  (-> 0.641, <- 0.708)
     linear_2_weight = self.linear_2.weight;  (-> 1.0, <- 0.691)
     linear_2_bias = self.linear_2.bias;  (-> 0.0, <- 0.998)
     linear_1 = U.linear(gelu, linear_2_weight, linear_2_bias, 'gmean');  (-> 0.973, <- 1.0)

--- a/unit_scaling/transforms/_unit_scale.py
+++ b/unit_scaling/transforms/_unit_scale.py
@@ -81,6 +81,7 @@ def _unconstrain_node(node: Node) -> None:
     if (
         node.op == "call_function"
         and callable(node.target)
+        and not isinstance(node.target, BuiltinFunctionType)
         and "constraint" in signature(node.target).parameters
     ):
         logger.info("unconstraining node: %s", node)


### PR DESCRIPTION
A few changes:

 - Get `setup.py` to depend on the right version of poptorch-experimental-addons, when on IPU
 - Small fix for handling of `torch.arange` (`builtin_function_or_method`) in the unit scaling backend
 - Allow auto-conversion of `nn.GELU()` by adding `approximate` as an unsupported arg (although it probably could be "approximately supported" :smile:)
 - Add IPU support (via pea) to `formats.FPFormat`
