### PR TITLE
Support sdist builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 .vscode
 
 /build
+/dist
 /local
 
 /docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Just a minor tweak: `setup.py install` on the client doesn't find `requirements.txt` since it's not packaged in the sdist `.tar.gz` by default.