### PR TITLE
Fix a torch FX error on torch-2.0.1 '__annotations__ must be set to a dict object'

### DIFF
--- a/unit_scaling/utils.py
+++ b/unit_scaling/utils.py
@@ -206,6 +206,9 @@ class _DeepTracer(fx.Tracer):
         self.recurse_modules = recurse_modules
         self.target_to_function: Dict[str, FunctionType] = {}
         self.function_to_node: Dict[FunctionType, fx.Node] = {}
+        # Fixes: `TypeError: __annotations__ must be set to a dict object`
+        if id(FunctionType) in self._autowrap_function_ids:
+            self._autowrap_function_ids.remove(id(FunctionType))
 
     def is_leaf_module(self, m: nn.Module, module_qualified_name: str) -> bool:
         return not self.recurse_modules


### PR DESCRIPTION
FX is calling `functools.wraps` on `FunctionType`, for which `__annotations__` is a `getset_descriptor`. Seems easiest & should be safe to just remove `FunctionType` from the auto-wrapping.

Did you ever hit this?

---

Full error:

```sh
unit_scaling/utils.py:311: in analyse_module
    fx_graph = tracer.trace(module)
unit_scaling/utils.py:236: in trace
    graph = super().trace(root, concrete_args)
.venv/lib/python3.8/site-packages/torch/fx/_symbolic_trace.py:772: in trace
    _autowrap_check(
.venv/lib/python3.8/site-packages/torch/fx/_symbolic_trace.py:992: in _autowrap_check
    patcher.patch(frame_dict, name, _create_wrapped_func(value))
.venv/lib/python3.8/site-packages/torch/fx/_symbolic_trace.py:838: in _create_wrapped_func
    def wrapped(*args, **kwargs):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

wrapper = <function function at 0x7f7b7d4618b0>, wrapped = <class 'function'>, assigned = ('__module__', '__name__', '__qualname__', '__doc__', '__annotations__'), updated = ('__dict__',)

    def update_wrapper(wrapper,
                       wrapped,
                       assigned = WRAPPER_ASSIGNMENTS,
                       updated = WRAPPER_UPDATES):
        """Update a wrapper function to look like the wrapped function
    
           wrapper is the function to be updated
           wrapped is the original function
           assigned is a tuple naming the attributes assigned directly
           from the wrapped function to the wrapper function (defaults to
           functools.WRAPPER_ASSIGNMENTS)
           updated is a tuple naming the attributes of the wrapper that
           are updated with the corresponding attribute from the wrapped
           function (defaults to functools.WRAPPER_UPDATES)
        """
        for attr in assigned:
            try:
                value = getattr(wrapped, attr)
            except AttributeError:
                pass
            else:
>               setattr(wrapper, attr, value)
E               TypeError: __annotations__ must be set to a dict object

/usr/lib/python3.8/functools.py:55: TypeError
```