### PR TITLE
Add compile transform

### DIFF
--- a/unit_scaling/analysis.py
+++ b/unit_scaling/analysis.py
@@ -25,7 +25,7 @@ from .transforms import (
     track_scales,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from transformers.tokenization_utils_base import (  # type: ignore
         PreTrainedTokenizerBase,
     )

--- a/unit_scaling/tests/transforms/test_compile.py
+++ b/unit_scaling/tests/transforms/test_compile.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-
 from typing import Tuple
 
 import torch

--- a/unit_scaling/tests/transforms/test_compile.py
+++ b/unit_scaling/tests/transforms/test_compile.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from ...transforms import compile, unit_scale
+
+
+def test_compile() -> None:
+    class Module(nn.Module):  # pragma: no cover
+        def __init__(
+            self,
+            hidden_size: int,
+        ) -> None:
+            super().__init__()
+            self.layer_norm = nn.LayerNorm(hidden_size)
+            self.l1 = nn.Linear(hidden_size, 4 * hidden_size)
+            self.l2 = nn.Linear(4 * hidden_size, hidden_size)
+
+        def forward(self, input: Tensor) -> Tuple[Tensor, Tensor]:
+            input = self.layer_norm(input)
+            input = self.l1(input)
+            input = F.gelu(input)
+            input = self.l2(input)
+            input = F.dropout(input, 0.2)
+            return input, input.sum()
+
+    mod = Module(2**6)
+    x = torch.randn(2**3, 2**6)
+
+    compile(mod)(x)
+    compile(unit_scale(mod))(x)

--- a/unit_scaling/transforms/__init__.py
+++ b/unit_scaling/transforms/__init__.py
@@ -6,6 +6,7 @@ scaling."""
 # This all has to be done manually to keep mypy happy.
 # Removing the `--no-implicit-reexport` option ought to fix this, but doesn't appear to.
 
+from ._compile import compile
 from ._simulate_format import simulate_format, simulate_fp8
 from ._track_scales import (
     Metrics,
@@ -18,6 +19,7 @@ from ._unit_scale import unit_scale
 
 __all__ = [
     "Metrics",
+    "compile",
     "prune_non_float_tensors",
     "prune_same_scale_tensors",
     "prune_selected_nodes",

--- a/unit_scaling/transforms/_compile.py
+++ b/unit_scaling/transforms/_compile.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+from typing import TypeVar
+
+from torch import _TorchCompileInductorWrapper, nn
+
+from .utils import apply_transform
+
+M = TypeVar("M", bound=nn.Module)
+
+
+def compile(module: M) -> M:
+    """A transform that applies torch.compile to a module.
+
+    Note that this is slightly different to calling :code:`torch.compile(module)`.
+
+    The current version of :func:`torch.compile` doesn't allow for nested transforms, so
+    the following is not supported:
+
+    .. code-block:: python
+
+        import torch
+
+        from unit_scaling.transforms import unit_scale
+
+        module = torch.compile(unit_scale(module))
+
+    :mod:`unit_scaling.transforms` addresses this by introducing a range of composable
+    transforms. This works by moving the call to
+    :func:`torch._dynamo.optimize` within the :code:`forward()` method of the module
+    and only executing it on the first call to the module, or if a new transform
+    is applied, the optimised call being cached thereafter.
+
+    The :func:`unit_scaling.transforms.compile` function is one such composable
+    transform. This means that the following can be written:
+
+    .. code-block:: python
+
+        from unit_scaling.transforms import compile, unit_scale
+
+        module = compile(unit_scale(module))
+
+    This will successfully combine the three transforms in a single module. Note that
+    the call to compile must still come last, as its underlying backend returns a
+    standard :class:`torch.nn.Module` rather than a :class:`torch.fx.GraphModule`.
+
+    Currently :func:`unit_scaling.transforms.compile` does not support the ops needed
+    for the :func:`unit_scaling.transforms.simulate_fp8` transform, though this may
+    change in future PyTorch releases.
+
+    Modules implemented manually with unit-scaled layers (i.e. without the global
+    :code:`unit_scale(module)` transform) can still use :func:`torch.compile` in the
+    standardgit way.
+
+    Args:
+        module (M): the module to be compiled.
+
+    Returns:
+        M: the compiled module.
+    """
+    return apply_transform(  # type: ignore[no-any-return]
+        module, _TorchCompileInductorWrapper("default", None, None)  # type: ignore
+    )

--- a/unit_scaling/transforms/_compile.py
+++ b/unit_scaling/transforms/_compile.py
@@ -40,7 +40,7 @@ def compile(module: M) -> M:
 
         module = compile(unit_scale(module))
 
-    This will successfully combine the three transforms in a single module. Note that
+    This will successfully combine the two transforms in a single module. Note that
     the call to compile must still come last, as its underlying backend returns a
     standard :class:`torch.nn.Module` rather than a :class:`torch.fx.GraphModule`.
 
@@ -50,7 +50,7 @@ def compile(module: M) -> M:
 
     Modules implemented manually with unit-scaled layers (i.e. without the global
     :code:`unit_scale(module)` transform) can still use :func:`torch.compile` in the
-    standardgit way.
+    standard way.
 
     Args:
         module (M): the module to be compiled.

--- a/unit_scaling/transforms/_unit_scale.py
+++ b/unit_scaling/transforms/_unit_scale.py
@@ -227,12 +227,12 @@ def unit_scale(
     """**[Experimental]** Returns a unit-scaled version of the input model.
 
     Uses TorchDynamo to trace and transform the user-supplied module.
-    This transformation identifies all :mod:`torch.nn.functional` uses in the input
+    This transformation identifies all :class:`torch.nn.functional` uses in the input
     module, and replaces them with their unit-scaled equivalents, should they exist.
 
     The tracing procedure automatically recurses into modules
     (whether defined in libraries, or by the user), identifying inner calls to any
-    :mod:`torch.nn.functional` operations, to build a graph of fundamental operations.
+    :class:`torch.nn.functional` operations, to build a graph of fundamental operations.
     Unit scaling is then applied as a transformation on top of this graph.
 
     This transformation proceeds in five stages:

--- a/unit_scaling/transforms/utils.py
+++ b/unit_scaling/transforms/utils.py
@@ -173,12 +173,12 @@ def apply_transform(
 ) -> M:
     """Applies a graph transformation to a module.
 
-    The user-supplied `backend` represents a transformation of a
-    :class:`torch.fx.graph_module.GraphModule`. `apply_transform()` uses
+    The user-supplied :code:`backend` represents a transformation of a
+    :class:`torch.fx.graph_module.GraphModule`. :code:`apply_transform()` uses
     :func:`torch._dynamo.optimize` to apply this transformation to the module,
     returning a new transformed module.
 
-    Note that the current version of TorchDynamo (or :mod:`torch.compile`, which is a
+    Note that the current version of TorchDynamo (or :func:`torch.compile`, which is a
     wrapper around TorchDynamo) doesn't support nested transforms, so we implement our
     own system here. This makes it easy to nest transforms:
 
@@ -187,10 +187,10 @@ def apply_transform(
         module = apply_transform(apply_transform(module, backend_1), backend_2)
 
     However, it should be noted these transforms are not interoperable with the standard
-    :mod:`torch.compile` interface.
+    :func:`torch.compile` interface.
 
     This nesting system is implemented by moving the call to
-    :func:`torch._dynamo.optimize` within the `forward()` method of the module
+    :func:`torch._dynamo.optimize` within the :code:`forward()` method of the module
     (though it is only executed on the first call to the module, or if a new transform
     is applied, the optimised call being cached thereafter). This differs from the
     standard approach used with :func:`torch._dynamo.optimize`, but enables this


### PR DESCRIPTION
Frustratingly, I can't get the `compile` transform to work with the `simulate_fp8` transform. This is because the `torch.compile` backend doesn't currently support the `q.view(torch.int32)` operation in:

```
q = x.to(torch.float32)
q = torch.clip(x, -absmax, absmax)
q /= downscale
q = ((q.view(torch.int32) + offset) & ~mask).view(torch.float32)
q *= downscale
return q.to(x.dtype)
```

I had a little more success by replacing the view op with `torch.tensor(q.untyped_storage(), dtype=torch.int32).reshape_as(q)`. This appeared to work with `torch.compile` for a small module, but for the full module it started to complain it couldn't figure out the shape of the untyped storage object. I'm not sure why it worked for one but not the other, but for now I'm giving up.

This is frustrating as the notebook won't use compilation/operator-fusing, and hence will be slower for the `simulate_fp8` runs. But the good news is that the compile op contained in this PR still works with the `unit_scale` transform. I haven't tested on the latest nightly to see if it gets down to zero-overhead ... but we can still point to the `torch.compile` notebook I made a while back to show that zero-overhead is certainly possible.