### PR TITLE
PyTorch 2.1 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.egg-info
-.coverage
+.coverage*
 .env
 .mypy_cache
 __pycache__

--- a/unit_scaling/_modules.py
+++ b/unit_scaling/_modules.py
@@ -34,7 +34,7 @@ class GELU(nn.GELU):
         self.constraint = constraint
 
     def forward(self, input: Tensor) -> Tensor:
-        return U.gelu(  # type: ignore
+        return U.gelu(
             input,
             approximate=self.approximate,
             constraint=self.constraint,

--- a/unit_scaling/analysis.py
+++ b/unit_scaling/analysis.py
@@ -8,9 +8,9 @@ import re
 from math import isnan
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
-import matplotlib  # type: ignore[import]
-import matplotlib.colors  # type: ignore[import]
-import matplotlib.pyplot as plt  # type: ignore[import]
+import matplotlib
+import matplotlib.colors
+import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns  # type: ignore[import]
 from datasets import load_dataset  # type: ignore[import]
@@ -438,7 +438,7 @@ def plot(
                 for direction in ["fwd", "bwd"]:
                     draw_error_bar(n, direction)
 
-    return p
+    return p  # type: ignore[no-any-return]
 
 
 def visualiser(
@@ -512,7 +512,7 @@ def visualiser(
     _, loss = tracked_model(inputs, labels)
     if backward:
         loss.backward()
-    graph = tracked_model.scales_graph()  # type: ignore[operator]
+    graph = tracked_model.scales_graph()
     return plot(graph, **plot_kwargs)
 
 

--- a/unit_scaling/tests/test_analysis.py
+++ b/unit_scaling/tests/test_analysis.py
@@ -74,7 +74,7 @@ def test_graph_to_dataframe() -> None:
     loss = model(input)
     loss.backward()
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     df = graph_to_dataframe(graph)
 
     expected = pd.DataFrame.from_dict(
@@ -84,10 +84,10 @@ def test_graph_to_dataframe() -> None:
                 "x",
                 "relu",
                 "relu",
-                "self_linear_weight",
-                "self_linear_weight",
-                "self_linear_bias",
-                "self_linear_bias",
+                "linear_weight",
+                "linear_weight",
+                "linear_bias",
+                "linear_bias",
                 "linear",
                 "linear",
                 "sum_1",
@@ -173,7 +173,7 @@ def test_plot() -> None:
     loss = model(input)
     loss.backward()
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     axes = plot(graph, "demo", xmin=2**-20, xmax=2**10)
     assert axes
 

--- a/unit_scaling/tests/transforms/test_simulate_format.py
+++ b/unit_scaling/tests/transforms/test_simulate_format.py
@@ -70,7 +70,7 @@ def test_simulate_fp8_unit_scaled_linear() -> None:
 def test_simulate_fp8_attention() -> None:
     class Model(nn.Module):
         def forward(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
-            return F.scaled_dot_product_attention(q, k, v).sum()  # type: ignore
+            return F.scaled_dot_product_attention(q, k, v).sum()
 
     inputs = list(randn(2**8, 2**8, requires_grad=True) for _ in range(3))
     model = Model()
@@ -91,7 +91,7 @@ def test_simulate_fp8_attention() -> None:
 def test_simulate_fp8_unit_scaled_attention() -> None:
     class Model(nn.Module):
         def forward(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
-            return U.scaled_dot_product_attention(q, k, v).sum()  # type: ignore
+            return U.scaled_dot_product_attention(q, k, v).sum()
 
     inputs = list(randn(2**8, 2**8, requires_grad=True) for _ in range(3))
     model = Model()

--- a/unit_scaling/tests/transforms/test_track_scales.py
+++ b/unit_scaling/tests/transforms/test_track_scales.py
@@ -2,12 +2,14 @@
 
 import operator
 from math import pi, sqrt
-from typing import Tuple
+from typing import Any, Callable, Dict, Set, Tuple, Union
 
 import pytest
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn, randint, randn, randn_like
+from torch.fx.graph import Graph
+from torch.fx.node import Node
 
 from ...transforms import (
     prune_non_float_tensors,
@@ -15,6 +17,20 @@ from ...transforms import (
     prune_selected_nodes,
     track_scales,
 )
+
+
+def get_target(node: Node) -> Union[str, Callable]:  # type: ignore[type-arg]
+    return node.meta["clean_name"] if isinstance(node.target, str) else node.target
+
+
+def get_targets(graph: Graph) -> Set[Union[str, Callable]]:  # type: ignore[type-arg]
+    return set(get_target(node) for node in graph.nodes)
+
+
+def get_target_map(
+    graph: Graph,
+) -> Dict[Union[str, Callable], Dict[str, Any]]:  # type: ignore[type-arg]
+    return {get_target(node): node.meta for node in graph.nodes}
 
 
 def test_track_scales() -> None:
@@ -27,15 +43,15 @@ def test_track_scales() -> None:
 
     model = Model()
     model = track_scales(model)
-    assert len(model.scales_graph().nodes) == 0  # type: ignore[operator]
+    assert len(model.scales_graph().nodes) == 0
 
     input = randn(2**4, 2**10)
     loss = model(input)
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
 
     assert all("outputs_float_tensor" in n.meta for n in graph.nodes)
-    meta_map = {node.target: node.meta for node in graph.nodes}
+    meta_map = get_target_map(graph)
 
     assert "metrics" in meta_map["x"]
     assert meta_map["x"]["metrics"].bwd is None
@@ -68,16 +84,16 @@ def test_track_scales() -> None:
     assert meta_map[torch.ones_like]["metrics"].fwd.numel == 2**14
 
     assert "metrics" in meta_map[operator.add]
-    assert "metrics" in meta_map["sum"]
-    assert meta_map["sum"]["metrics"].fwd.numel == 1
+    assert "metrics" in meta_map["sum_1"]
+    assert meta_map["sum_1"]["metrics"].fwd.numel == 1
 
     loss.backward()
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
 
-    meta_map = {node.target: node.meta for node in graph.nodes}
+    meta_map = get_target_map(graph)
 
-    assert meta_map["sum"]["metrics"].bwd is not None
-    assert meta_map["sum"]["metrics"].bwd.numel == 1
+    assert meta_map["sum_1"]["metrics"].bwd is not None
+    assert meta_map["sum_1"]["metrics"].bwd.numel == 1
 
     assert meta_map[operator.add]["metrics"].bwd is not None
     assert meta_map[operator.add]["metrics"].bwd.mean_abs == 1.0
@@ -114,14 +130,14 @@ def test_prune_non_float_tensors() -> None:
     model = track_scales(model)
     model(idxs)
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     expected_targets = {
         "idxs",
-        "self_emb_weight",
+        "emb_weight",
         F.embedding,
         F.linear,
-        "self_linear_weight",
-        "self_linear_bias",
+        "linear_weight",
+        "linear_bias",
         F.softmax,
         torch.argmax,
         torch.unsqueeze,
@@ -130,11 +146,11 @@ def test_prune_non_float_tensors() -> None:
         "mean",
         "output",
     }
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     assert graph_targets == expected_targets
 
     graph = prune_non_float_tensors(graph)
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets -= {"idxs", torch.argmax, torch.unsqueeze}
     assert graph_targets == expected_targets
 
@@ -164,15 +180,15 @@ def test_prune_same_scale_tensors() -> None:
     model = track_scales(model)
     model(idxs)
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     expected_targets = {
         "idxs",
-        "self_emb_weight",
+        "emb_weight",
         F.embedding,
         "flatten",
         "view",
-        "self_linear_weight",
-        "self_linear_bias",
+        "linear_weight",
+        "linear_bias",
         F.linear,
         F.softmax,
         torch.argmax,
@@ -182,16 +198,16 @@ def test_prune_same_scale_tensors() -> None:
         operator.iadd,
         "output",
     }
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     assert graph_targets == expected_targets
 
     graph = prune_same_scale_tensors(graph)
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets -= {"flatten", "view"}
     assert graph_targets == expected_targets
 
     graph = prune_same_scale_tensors(graph, rtol=2**-4)
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets -= {torch.gather, F.embedding}
     assert graph_targets == expected_targets
 
@@ -211,30 +227,30 @@ def test_prune_same_scale_tensors_with_grad() -> None:
     model = track_scales(model)
     loss = model(input)
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     expected_targets = {
         "a",
         operator.truediv,
         operator.mul,
         F.relu,
         operator.sub,
-        "sum",
+        "sum_1",
         "output",
     }
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     assert graph_targets == expected_targets
 
     graph = prune_same_scale_tensors(graph)
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets -= {operator.truediv, operator.mul}
     assert graph_targets == expected_targets
 
     # The mul still has the same scale before & after in the fwd pass, but the same is
     # not true for its grads. It should no longer be pruned after `loss.backward`.
     loss.backward()
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     graph = prune_same_scale_tensors(graph)
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets.add(operator.mul)
     assert graph_targets == expected_targets
 
@@ -252,19 +268,19 @@ def test_prune_selected_nodes() -> None:
     model = track_scales(model)
     model(input)
 
-    graph = model.scales_graph()  # type: ignore[operator]
+    graph = model.scales_graph()
     expected_targets = {
         "x",
         operator.add,
         F.relu,
         torch.abs,
-        "sum",
+        "sum_1",
         "output",
     }
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     assert graph_targets == expected_targets
 
     graph = prune_selected_nodes(graph, targets=[torch.abs, F.relu])
-    graph_targets = set(node.target for node in graph.nodes)
+    graph_targets = get_targets(graph)
     expected_targets -= {torch.abs, F.relu}
     assert graph_targets == expected_targets

--- a/unit_scaling/transforms/_track_scales.py
+++ b/unit_scaling/transforms/_track_scales.py
@@ -171,7 +171,10 @@ def _add_tabular_html_display(g: Graph) -> None:
 
 
 def _clean_node_name(name: str) -> str:
-    return name.replace("l__self___", "").replace("l_", "").strip("_")
+    replace_strs = ["l__self___", "L__self___", "l_", "L_"]
+    for r in replace_strs:
+        name = name.replace(r, "")
+    return name.strip("_")
 
 
 def _is_float_tensor(a: Any) -> bool:
@@ -198,6 +201,9 @@ class _Tracker(Interpreter):
             out = _Track.apply(out, n.meta)  # type: ignore
         return out
 
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return super().run(*args, **kwargs)
+
 
 def scale_tracking_backend(graph_holder: List[Graph]) -> Backend:
     def inner_backend(
@@ -205,7 +211,7 @@ def scale_tracking_backend(graph_holder: List[Graph]) -> Backend:
     ) -> Callable[..., Any]:
         _add_tabular_html_display(gm.graph)  # displays full info in notebooks
         graph_holder[0] = gm.graph  # allows graph to be accessed from outside
-        return _Tracker(gm).run  # type: ignore[no-any-return]
+        return _Tracker(gm)
 
     return inner_backend
 

--- a/unit_scaling/transforms/utils.py
+++ b/unit_scaling/transforms/utils.py
@@ -156,7 +156,13 @@ def _compose_backends(backends: Iterable[Backend]) -> Backend:
         gm: GraphModule, example_inputs: List[Tensor]
     ) -> Callable[..., Any]:
         for b in backends:
-            gm = b(gm, example_inputs)  # type: ignore[assignment]
+            new_gm = b(gm, example_inputs)
+            new_gm._param_name_to_source = getattr(  # type: ignore
+                gm,
+                "_param_name_to_source",
+                None,
+            )
+            gm = new_gm  # type: ignore[assignment]
         return gm
 
     return composite_backend


### PR DESCRIPTION
Fixes to make unit tests pass / everything work with PyTorch 2.1:

- Lots of small mypy changes
- Dynamo has changed naming scheme slightly - fixes to accommodate that
- Dynamo is now relying on a variable it adds to modules named `_param_name_to_source` - fix to maintain this when chaining backend calls
- The above fix only works if the `_Tracker` class is callable - fix to make this so