### PR TITLE
Parametrize the number of random bits used in stochastic rounding

### DIFF
--- a/unit_scaling/formats.py
+++ b/unit_scaling/formats.py
@@ -28,13 +28,13 @@ class FPFormat:
     exponent_bits: int
     mantissa_bits: int
     rounding: str = "stochastic"  # "stochastic|nearest"
-    srbits: int = 0 # Number of bits for stochastic rounding, zero => use all bits
+    srbits: int = 0  # Number of bits for stochastic rounding, zero => use all bits
 
     def __post_init__(self) -> None:
         assert self.exponent_bits >= 2, "FPFormat requires at least 2 exponent bits"
-        assert self.srbits == 0 or self.rounding == "stochastic", (
-            "Nonzero srbits for non-stochastic rounding"
-        )
+        assert (
+            self.srbits == 0 or self.rounding == "stochastic"
+        ), "Nonzero srbits for non-stochastic rounding"
         if self.srbits == 0 and self.rounding == "stochastic":
             self.srbits = 23 - self.mantissa_bits
 
@@ -81,11 +81,14 @@ class FPFormat:
         mask = torch.tensor(2 ** (23 - self.mantissa_bits) - 1, device=x.device)
         if self.rounding == "stochastic":
             srbitsbar = 23 - self.mantissa_bits - self.srbits
-            offset = torch.randint(  # type: ignore[call-overload]
-                0, 2**self.srbits, x.shape, dtype=torch.int32, device=x.device
-            ) << srbitsbar
+            offset = (
+                torch.randint(
+                    0, 2**self.srbits, x.shape, dtype=torch.int32, device=x.device
+                )
+                << srbitsbar
+            )
             # Correct for bias.  We can do this only for srbits < 23-mantissa_bits,
-            # but it is only likely to matter when srbits is small. 
+            # but it is only likely to matter when srbits is small.
             if srbitsbar > 0:
                 offset += 1 << (srbitsbar - 1)
 

--- a/unit_scaling/formats.py
+++ b/unit_scaling/formats.py
@@ -28,9 +28,15 @@ class FPFormat:
     exponent_bits: int
     mantissa_bits: int
     rounding: str = "stochastic"  # "stochastic|nearest"
+    srbits: int = 0 # Number of bits for stochastic rounding, zero => use all bits
 
     def __post_init__(self) -> None:
         assert self.exponent_bits >= 2, "FPFormat requires at least 2 exponent bits"
+        assert self.srbits == 0 or self.rounding == "stochastic", (
+            "Nonzero srbits for non-stochastic rounding"
+        )
+        if self.srbits == 0 and self.rounding == "stochastic":
+            self.srbits = 23 - self.mantissa_bits
 
     @property
     def bits(self) -> int:
@@ -75,8 +81,9 @@ class FPFormat:
         mask = torch.tensor(2 ** (23 - self.mantissa_bits) - 1, device=x.device)
         if self.rounding == "stochastic":
             offset = torch.randint(  # type: ignore[call-overload]
-                0, mask + 1, x.shape, dtype=torch.int32, device=x.device
-            )
+                0, 2**self.srbits, x.shape, dtype=torch.int32, device=x.device
+            ) << (23 - self.mantissa_bits - self.srbits)
+            assert (offset <= mask).all()
         elif self.rounding == "nearest":
             offset = mask // 2
         else:  # pragma: no cover

--- a/unit_scaling/tests/test_formats.py
+++ b/unit_scaling/tests/test_formats.py
@@ -30,13 +30,14 @@ def test_fp_format_rounding() -> None:
     assert collections.Counter(y_nearest.tolist()) == {-1.5: n}
 
     for srbits in (0, 13):
-      y_stochastic = FPFormat(2, 1, rounding="stochastic", srbits=srbits).quantise(torch.full((n,), x))
-      count = collections.Counter(y_stochastic.tolist())
-      assert count.keys() == {-1.5, -1.0}
-      expected_ratio = (1.35 - 1.0) / 0.5
-      nearest_ratio = count[-1.5] / sum(count.values())
-      std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
-      assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
+        srformat = FPFormat(2, 1, rounding="stochastic", srbits=srbits)
+        y_stochastic = srformat.quantise(torch.full((n,), x))
+        count = collections.Counter(y_stochastic.tolist())
+        assert count.keys() == {-1.5, -1.0}
+        expected_ratio = (1.35 - 1.0) / 0.5
+        nearest_ratio = count[-1.5] / sum(count.values())
+        std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
+        assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
 
 
 def test_fp_format_bwd() -> None:

--- a/unit_scaling/tests/test_formats.py
+++ b/unit_scaling/tests/test_formats.py
@@ -29,13 +29,14 @@ def test_fp_format_rounding() -> None:
     y_nearest = FPFormat(2, 1, rounding="nearest").quantise(torch.full((n,), x))
     assert collections.Counter(y_nearest.tolist()) == {-1.5: n}
 
-    y_stochastic = FPFormat(2, 1, rounding="stochastic").quantise(torch.full((n,), x))
-    count = collections.Counter(y_stochastic.tolist())
-    assert count.keys() == {-1.5, -1.0}
-    expected_ratio = (1.35 - 1.0) / 0.5
-    nearest_ratio = count[-1.5] / sum(count.values())
-    std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
-    assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
+    for srbits in (0, 13):
+      y_stochastic = FPFormat(2, 1, rounding="stochastic", srbits=srbits).quantise(torch.full((n,), x))
+      count = collections.Counter(y_stochastic.tolist())
+      assert count.keys() == {-1.5, -1.0}
+      expected_ratio = (1.35 - 1.0) / 0.5
+      nearest_ratio = count[-1.5] / sum(count.values())
+      std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
+      assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
 
 
 def test_fp_format_bwd() -> None:


### PR DESCRIPTION
Small change to allow the number of random bits used in stochastic rounding to be specified.
The calculation is slightly modified to avoid bias, e.g. the following graph shows how the stochastically rounded values approach the full-precision values:
![image](https://github.com/graphcore-research/unit-scaling/assets/128119/88550fa8-f6d6-43f5-b73d-f3533748e2c9)

```py
from matplotlib import pyplot as plt
import torch
import unit_scaling
from unit_scaling.formats import FPFormat

srnumbits = 2

fmt = FPFormat(5,2, "stochastic", srnumbits)

vs = torch.arange(0.9, 2.7, 1.0 / 117, dtype=torch.float32)

# Stochastic rounding
rvs = torch.zeros_like(vs)
nsamples = 5000
for n in range(nsamples):
    rvs += fmt.quantise(vs)
rvs /= nsamples

# round to nearest
fmt_nearest = FPFormat(5,2, "nearest")
rn = fmt_nearest.quantise(vs)

plt.plot(vs, vs, label="True value", color="k")
plt.plot(vs, rn, label="Round to nearest", color="orange")
plt.plot(vs, rvs, label=f"Stochastic, {srnumbits} bits", color="green")
plt.xlabel("Input float value")
plt.ylabel(f"Average of rounded values, {nsamples} samples")
plt.legend()
```