### PR TITLE
Fix recursion in torch_nn_modules_to_user_modules()

### DIFF
--- a/unit_scaling/tests/transforms/test_unit_scale.py
+++ b/unit_scaling/tests/transforms/test_unit_scale.py
@@ -40,7 +40,7 @@ def test_unit_scale(caplog: LogCaptureFixture) -> None:
             return input, input.sum()
 
     input = randn(2**6, 2**10, requires_grad=True)
-    model = MLPLayer(2**10)
+    model = nn.Sequential(MLPLayer(2**10))
     model = unit_scale(model, replace={custom_gelu: F.gelu})
     output, loss = model(input)
     loss.backward()
@@ -48,9 +48,9 @@ def test_unit_scale(caplog: LogCaptureFixture) -> None:
     assert_unit_scaled(
         output,
         input.grad,
-        model.layer_norm.weight.grad,
-        model.l1.weight.grad,
-        model.l2.weight.grad,
+        model[0].layer_norm.weight.grad,
+        model[0].l1.weight.grad,
+        model[0].l2.weight.grad,
         abs=0.2,
     )
 

--- a/unit_scaling/transforms/utils.py
+++ b/unit_scaling/transforms/utils.py
@@ -47,7 +47,9 @@ def torch_nn_modules_to_user_modules(mod: nn.Module) -> Any:
     is to call `module = torch_nn_modules_to_user_modules(module)`.
     """
 
-    for n, submod in mod.named_modules():
+    for n, submod in mod.named_children():
+        torch_nn_modules_to_user_modules(submod)
+
         # Mirroring the check at https://github.com/pytorch/pytorch/blob/34bce27f0d12bf7226b37dfe365660aad456701a/torch/_dynamo/variables/nn_module.py#L307 # noqa: E501
         if submod.__module__.startswith(("torch.nn.", "torch.ao.")):
             # Generate a new name, so e.g. torch.nn.modules.sparse.Embedding

--- a/unit_scaling/transforms/utils.py
+++ b/unit_scaling/transforms/utils.py
@@ -34,7 +34,7 @@ Backend = Callable[[GraphModule, List[Tensor]], Callable[..., Any]]
 _unit_scaled_functions = [getattr(U, f) for f in U.__all__]
 
 
-def torch_nn_modules_to_user_modules(mod: nn.Module) -> Any:
+def torch_nn_modules_to_user_modules(mod: nn.Module) -> None:
     """
     Convert torch.nn.module classes to `trivial_subclass` versions.
 
@@ -64,7 +64,8 @@ def torch_nn_modules_to_user_modules(mod: nn.Module) -> Any:
 
             # Initialize and copy state using pickle
             newsubmod = newmodtype.__new__(newmodtype)  # type: ignore [call-overload]
-            newsubmod.__setstate__(submod.__getstate__())
+            state = submod.__getstate__()  # type: ignore [no-untyped-call]
+            newsubmod.__setstate__(state)
 
             # Update module in mod
             setattr(mod, n, newsubmod)


### PR DESCRIPTION
This fixes a regression in the auto-conversion of GPT in the `out-of-the-box-fp8-training` notebook.

Current state:

```python
mod = type("Custom", (nn.Module,), {})()
mod.child = type("CustomChild", (nn.Module,), {})()
mod.child.lin = nn.Linear(10, 20)

print(unit_scale(mod))
# Custom(
#   (child): CustomChild(
#     (lin): Linear(in_features=10, out_features=20, bias=True)
#   )
#   (child.lin): trivial_subclass_modules_linear_Linear(in_features=10, out_features=20, bias=True)
# )
```

In `torch_nn_modules_to_user_modules()`, since `setattr(mod, n, newsubmod)` happily sets a non-valid-identifier key `n` such as `"child.lin"` without recursing, we get new child modules rather than replacing the existing ones.

This patch:

```python
print(unit_scale(mod))
# Custom(
#   (child): CustomChild(
#     (lin): trivial_subclass_modules_linear_Linear(in_features=10, out_features=20, bias=True)
#   )
# )
```

(There may still be some issues, e.g. when module instances are shared by different parents - after conversion they could become un-shared.)
