### PR TITLE
Remove the constraint argument in the container modules uu.{MLP, MHSA}

### DIFF
--- a/unit_scaling/_version.py
+++ b/unit_scaling/_version.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-__version__ = "0.2"
+__version__ = "0.3"

--- a/unit_scaling/tests/test_modules.py
+++ b/unit_scaling/tests/test_modules.py
@@ -201,6 +201,12 @@ def test_mlp() -> None:
 
     assert float(output.std()) == pytest.approx(1, abs=0.2)
 
+    assert_unit_scaled(
+        model.linear_1.weight.grad,
+        model.linear_gate.weight.grad,
+        model.linear_2.weight.grad,
+    )
+
     assert_not_unit_scaled(
         model.linear_1.weight, model.linear_gate.weight, model.linear_2.weight
     )

--- a/unit_scaling/tests/test_utils.py
+++ b/unit_scaling/tests/test_utils.py
@@ -29,12 +29,12 @@ def test_analyse_mlp() -> None:
 def forward(self, input : Tensor) -> Tensor:
     input_1 = input;  (-> 1.0, <- 1.44)
     linear_1_weight = self.linear_1.weight;  (-> 1.0, <- 0.503)
-    linear = U.linear(input_1, linear_1_weight, None, 'to_output_scale');  (-> 1.0, <- 0.502)
+    linear = U.linear(input_1, linear_1_weight, None, None);  (-> 1.0, <- 0.502)
     linear_gate_weight = self.linear_gate.weight;  (-> 1.0, <- 0.519)
-    linear_1 = U.linear(input_1, linear_gate_weight, None, 'to_output_scale');  (-> 1.0, <- 0.518)
+    linear_1 = U.linear(input_1, linear_gate_weight, None, None);  (-> 1.0, <- 0.518)
     silu_glu = U.silu_glu(linear, linear_1);  (-> 1.0, <- 0.5)
     linear_2_weight = self.linear_2.weight;  (-> 1.0, <- 1.0)
-    linear_2 = U.linear(silu_glu, linear_2_weight, None, 'to_output_scale');  (-> 1.0, <- 1.0)
+    linear_2 = U.linear(silu_glu, linear_2_weight, None, None);  (-> 1.0, <- 1.0)
     return linear_2
     """.strip()  # noqa: E501
 


### PR DESCRIPTION
This isn't needed for MLP, which can set constraint=None and maintain consistent forward and backward passes. It is dangerous for MHSA, as gradients are incorrect. It seems best to remove this argument.

Reported in #70.
